### PR TITLE
Store uploads in dated Drive folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Rules:
 - The display name uses the server display name first, then falls back to Discord global name, then username
 - Message text is truncated to the first 100 characters
 - The dated folder is created automatically if it does not already exist
+- The dated folder and time stamp use the app server's local timezone
 - If the base filename already exists, a suffix is added:
   `_1`, `_2`, `_3`, and so on
 

--- a/README.md
+++ b/README.md
@@ -203,26 +203,33 @@ The web setup flow also supports mapping multiple channels directly.
 
 ## File Naming
 
-Files are named using this pattern:
+Uploads are stored in a dated subfolder inside the mapped Google Drive folder:
 
 ```text
-yyyy-mm-dd-hh-mm - display name - comment.ext
+YYYY-mm-dd/
+```
+
+Files inside that subfolder are named using this pattern:
+
+```text
+display name - hh-mm-ss - comment.ext
 ```
 
 Rules:
 
 - If there is no message text, the filename becomes:
-  `yyyy-mm-dd-hh-mm - display name.ext`
+  `display name - hh-mm-ss.ext`
 - The display name uses the server display name first, then falls back to Discord global name, then username
 - Message text is truncated to the first 100 characters
+- The dated folder is created automatically if it does not already exist
 - If the base filename already exists, a suffix is added:
   `_1`, `_2`, `_3`, and so on
 
 Example:
 
 ```text
-2026-03-15-12-54 - Alice Example - Whiteboard photo.png
-2026-03-15-12-54 - Alice Example - Whiteboard photo_1.png
+2026-03-15/Alice Example - 12-54-11 - Whiteboard photo.png
+2026-03-15/Alice Example - 12-54-11 - Whiteboard photo_1.png
 ```
 
 ## Upload Confirmation Message
@@ -232,19 +239,19 @@ Successful uploads respond in Discord with a folder link and filename preview.
 Single file:
 
 ```md
-Uploaded to [_From Discord](https://drive.google.com/drive/folders/your-folder-id).
+Uploaded to [_From Discord/2026-03-15](https://drive.google.com/drive/folders/your-folder-id).
 
 File name:
-- 2026-03-15-12-54 - Alice Example.png
+- Alice Example - 12-54-11.png
 ```
 
 Multiple files:
 
 ```md
-Uploaded to [_From Discord](https://drive.google.com/drive/folders/your-folder-id).
+Uploaded to [_From Discord/2026-03-15](https://drive.google.com/drive/folders/your-folder-id).
 
 File names starting from:
-- 2026-03-15-12-42 - Alice Example.jpg
+- Alice Example - 12-42-02.jpg
 ```
 
 ## Development

--- a/src/handlers/message-handler.js
+++ b/src/handlers/message-handler.js
@@ -2,7 +2,7 @@ import { Client, GatewayIntentBits, REST, Routes } from 'discord.js';
 import { ConfigStore } from '../services/config-store.js';
 import { GoogleAuthService } from '../services/google-auth.js';
 import { GoogleDriveService } from '../services/google-drive.js';
-import { generateFileName, reserveDuplicateFilename } from '../utils/file-namer.js';
+import { formatUploadDate, generateFileName, reserveDuplicateFilename } from '../utils/file-namer.js';
 import { formatUploadStatusMessage } from '../utils/upload-status.js';
 import { createLogger } from '../utils/logger.js';
 import fetch from 'node-fetch';
@@ -99,7 +99,11 @@ export class DiscordBot {
 
     logger.info(`Processing ${supportedAttachments.length} attachments from channel ${channel.name}`);
 
-    const { driveService, existingFilenames } = await this.prepareDriveUploadContext(channelConfig.driveFolderId);
+    const uploadDate = formatUploadDate(message.createdAt);
+    const { driveService, uploadFolder, existingFilenames } = await this.prepareDriveUploadContext(
+      channelConfig.driveFolderId,
+      uploadDate
+    );
     const reservedFilenames = supportedAttachments.map((attachment) => {
       const baseFilename = generateFileName(
         attachment.name,
@@ -112,7 +116,7 @@ export class DiscordBot {
     });
 
     const uploadTasks = supportedAttachments.map((attachment, index) =>
-      this.createUploadTask(attachment, reservedFilenames[index], channelConfig.driveFolderId, driveService)
+      this.createUploadTask(attachment, reservedFilenames[index], uploadFolder.id, driveService)
     );
 
     // Send initial response
@@ -142,8 +146,8 @@ export class DiscordBot {
       responseText = formatUploadStatusMessage({
         successfulCount: successful,
         totalCount: supportedAttachments.length,
-        folderName: channelConfig.folderName,
-        folderId: channelConfig.driveFolderId,
+        folderName: `${channelConfig.folderName}/${uploadFolder.name}`,
+        folderId: uploadFolder.id,
         uploadedFilenames
       });
     } else if (failed === supportedAttachments.length) {
@@ -152,8 +156,8 @@ export class DiscordBot {
       responseText = formatUploadStatusMessage({
         successfulCount: successful,
         totalCount: supportedAttachments.length,
-        folderName: channelConfig.folderName,
-        folderId: channelConfig.driveFolderId,
+        folderName: `${channelConfig.folderName}/${uploadFolder.name}`,
+        folderId: uploadFolder.id,
         uploadedFilenames
       });
     }
@@ -178,7 +182,7 @@ export class DiscordBot {
     }
   }
 
-  async prepareDriveUploadContext(folderId) {
+  async prepareDriveUploadContext(folderId, uploadDate) {
     const googleTokens = await this.configStore.getGoogleTokens();
     if (!googleTokens) {
       throw new Error('Google Drive not configured');
@@ -194,10 +198,12 @@ export class DiscordBot {
     }
 
     const driveService = new GoogleDriveService(authService.getAuthClient());
-    const existingFiles = await driveService.getFilesByFolder(folderId);
+    const uploadFolder = await driveService.ensureFolder(uploadDate, folderId);
+    const existingFiles = await driveService.getFilesByFolder(uploadFolder.id);
 
     return {
       driveService,
+      uploadFolder,
       existingFilenames: existingFiles.map((file) => file.name)
     };
   }

--- a/src/handlers/message-handler.js
+++ b/src/handlers/message-handler.js
@@ -2,7 +2,7 @@ import { Client, GatewayIntentBits, REST, Routes } from 'discord.js';
 import { ConfigStore } from '../services/config-store.js';
 import { GoogleAuthService } from '../services/google-auth.js';
 import { GoogleDriveService } from '../services/google-drive.js';
-import { formatUploadDate, generateFileName, reserveDuplicateFilename } from '../utils/file-namer.js';
+import { formatUploadDate, generateFileName, getUploadTimeZone, reserveDuplicateFilename } from '../utils/file-namer.js';
 import { formatUploadStatusMessage } from '../utils/upload-status.js';
 import { createLogger } from '../utils/logger.js';
 import fetch from 'node-fetch';
@@ -99,7 +99,8 @@ export class DiscordBot {
 
     logger.info(`Processing ${supportedAttachments.length} attachments from channel ${channel.name}`);
 
-    const uploadDate = formatUploadDate(message.createdAt);
+    const uploadTimeZone = getUploadTimeZone();
+    const uploadDate = formatUploadDate(message.createdAt, uploadTimeZone);
     const { driveService, uploadFolder, existingFilenames } = await this.prepareDriveUploadContext(
       channelConfig.driveFolderId,
       uploadDate
@@ -109,7 +110,8 @@ export class DiscordBot {
         attachment.name,
         message.content,
         message.createdAt,
-        message.member?.displayName || message.author?.globalName || message.author?.username || ''
+        message.member?.displayName || message.author?.globalName || message.author?.username || '',
+        uploadTimeZone
       );
 
       return reserveDuplicateFilename(baseFilename, existingFilenames);

--- a/src/services/google-drive.js
+++ b/src/services/google-drive.js
@@ -85,6 +85,15 @@ export class GoogleDriveService {
     }
   }
 
+  async ensureFolder(name, parentId = null) {
+    const existingFolder = await this.findFolderByName(name, parentId);
+    if (existingFolder) {
+      return existingFolder;
+    }
+
+    return this.createFolder(name, parentId);
+  }
+
   async uploadFile(fileBuffer, fileName, folderId, mimeType) {
     try {
       const fileMetadata = {

--- a/src/services/google-drive.js
+++ b/src/services/google-drive.js
@@ -7,6 +7,7 @@ const logger = createLogger('GoogleDrive');
 export class GoogleDriveService {
   constructor(authClient) {
     this.drive = google.drive({ version: 'v3', auth: authClient });
+    this.pendingFolderEnsures = new Map();
   }
 
   escapeDriveQueryValue(value) {
@@ -86,12 +87,28 @@ export class GoogleDriveService {
   }
 
   async ensureFolder(name, parentId = null) {
-    const existingFolder = await this.findFolderByName(name, parentId);
-    if (existingFolder) {
-      return existingFolder;
+    const folderKey = `${parentId || 'root'}:${name}`;
+    const pendingEnsure = this.pendingFolderEnsures.get(folderKey);
+    if (pendingEnsure) {
+      return pendingEnsure;
     }
 
-    return this.createFolder(name, parentId);
+    const ensurePromise = (async () => {
+      const existingFolder = await this.findFolderByName(name, parentId);
+      if (existingFolder) {
+        return existingFolder;
+      }
+
+      return this.createFolder(name, parentId);
+    })();
+
+    this.pendingFolderEnsures.set(folderKey, ensurePromise);
+
+    try {
+      return await ensurePromise;
+    } finally {
+      this.pendingFolderEnsures.delete(folderKey);
+    }
   }
 
   async uploadFile(fileBuffer, fileName, folderId, mimeType) {

--- a/src/utils/file-namer.js
+++ b/src/utils/file-namer.js
@@ -2,15 +2,23 @@ export function generateFileName(originalName, messageContent = '', timestamp = 
   const nameParts = originalName.split('.');
   const extension = nameParts.length > 1 ? nameParts.pop().toLowerCase() : '';
 
-  const date = timestamp.toISOString().slice(0, 16).replace('T', '-').replace(/:/g, '-');
+  const time = formatUploadTime(timestamp);
   const safeAuthor = sanitizeForFilename(authorName) || 'Unknown user';
   const safeComment = sanitizeForFilename(messageContent, 100);
 
   const baseFileName = safeComment
-    ? `${date} - ${safeAuthor} - ${safeComment}`
-    : `${date} - ${safeAuthor}`;
+    ? `${safeAuthor} - ${time} - ${safeComment}`
+    : `${safeAuthor} - ${time}`;
 
   return extension ? `${baseFileName}.${extension}` : baseFileName;
+}
+
+export function formatUploadDate(timestamp = new Date()) {
+  return timestamp.toISOString().slice(0, 10);
+}
+
+export function formatUploadTime(timestamp = new Date()) {
+  return timestamp.toISOString().slice(11, 19).replace(/:/g, '-');
 }
 
 export function sanitizeForFilename(text, maxLength = 80) {
@@ -37,19 +45,19 @@ export function handleDuplicateFilename(filename, existingFilenames) {
   if (!existingFilenames.includes(filename)) {
     return filename;
   }
-  
+
   const nameParts = filename.split('.');
   const extension = nameParts.pop();
   const baseName = nameParts.join('.');
-  
+
   let counter = 1;
   let newFilename;
-  
+
   do {
     newFilename = `${baseName}_${counter}.${extension}`;
     counter++;
   } while (existingFilenames.includes(newFilename));
-  
+
   return newFilename;
 }
 

--- a/src/utils/file-namer.js
+++ b/src/utils/file-namer.js
@@ -1,8 +1,14 @@
-export function generateFileName(originalName, messageContent = '', timestamp = new Date(), authorName = '') {
+export function generateFileName(
+  originalName,
+  messageContent = '',
+  timestamp = new Date(),
+  authorName = '',
+  timeZone = getUploadTimeZone()
+) {
   const nameParts = originalName.split('.');
   const extension = nameParts.length > 1 ? nameParts.pop().toLowerCase() : '';
 
-  const time = formatUploadTime(timestamp);
+  const time = formatUploadTime(timestamp, timeZone);
   const safeAuthor = sanitizeForFilename(authorName) || 'Unknown user';
   const safeComment = sanitizeForFilename(messageContent, 100);
 
@@ -13,12 +19,40 @@ export function generateFileName(originalName, messageContent = '', timestamp = 
   return extension ? `${baseFileName}.${extension}` : baseFileName;
 }
 
-export function formatUploadDate(timestamp = new Date()) {
-  return timestamp.toISOString().slice(0, 10);
+export function getUploadTimeZone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 }
 
-export function formatUploadTime(timestamp = new Date()) {
-  return timestamp.toISOString().slice(11, 19).replace(/:/g, '-');
+function getFormatterParts(timestamp, timeZone, options) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    ...options
+  }).formatToParts(timestamp);
+}
+
+function getPart(parts, type) {
+  return parts.find((part) => part.type === type)?.value || '';
+}
+
+export function formatUploadDate(timestamp = new Date(), timeZone = getUploadTimeZone()) {
+  const parts = getFormatterParts(timestamp, timeZone, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+
+  return `${getPart(parts, 'year')}-${getPart(parts, 'month')}-${getPart(parts, 'day')}`;
+}
+
+export function formatUploadTime(timestamp = new Date(), timeZone = getUploadTimeZone()) {
+  const parts = getFormatterParts(timestamp, timeZone, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  });
+
+  return `${getPart(parts, 'hour')}-${getPart(parts, 'minute')}-${getPart(parts, 'second')}`;
 }
 
 export function sanitizeForFilename(text, maxLength = 80) {

--- a/tests/services/google-drive.test.js
+++ b/tests/services/google-drive.test.js
@@ -64,4 +64,44 @@ describe('GoogleDriveService', () => {
     }));
     expect(files).toEqual([{ id: 'file123', name: 'photo.png' }]);
   });
+
+  test('reuses an existing child folder when ensuring a folder', async () => {
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: [{ id: 'folder456', name: '2026-03-16', parents: ['parent123'] }]
+      }
+    });
+
+    const folder = await driveService.ensureFolder('2026-03-16', 'parent123');
+
+    expect(mockDriveFiles.list).toHaveBeenCalledWith(expect.objectContaining({
+      q: 'mimeType=\'application/vnd.google-apps.folder\' and trashed=false and name=\'2026-03-16\' and \'parent123\' in parents'
+    }));
+    expect(mockDriveFiles.create).not.toHaveBeenCalled();
+    expect(folder).toEqual({ id: 'folder456', name: '2026-03-16', parents: ['parent123'] });
+  });
+
+  test('creates a child folder when ensuring a missing folder', async () => {
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: []
+      }
+    });
+    mockDriveFiles.create.mockResolvedValueOnce({
+      data: { id: 'folder789', name: '2026-03-16' }
+    });
+
+    const folder = await driveService.ensureFolder('2026-03-16', 'parent123');
+
+    expect(mockDriveFiles.create).toHaveBeenCalledWith(expect.objectContaining({
+      resource: {
+        name: '2026-03-16',
+        mimeType: 'application/vnd.google-apps.folder',
+        parents: ['parent123']
+      },
+      fields: 'id, name',
+      supportsAllDrives: true
+    }));
+    expect(folder).toEqual({ id: 'folder789', name: '2026-03-16' });
+  });
 });

--- a/tests/services/google-drive.test.js
+++ b/tests/services/google-drive.test.js
@@ -104,4 +104,40 @@ describe('GoogleDriveService', () => {
     }));
     expect(folder).toEqual({ id: 'folder789', name: '2026-03-16' });
   });
+
+  test('serialises concurrent ensureFolder calls for the same child folder', async () => {
+    let resolveList;
+    let resolveCreate;
+    const listPromise = new Promise((resolve) => {
+      resolveList = resolve;
+    });
+    const createPromise = new Promise((resolve) => {
+      resolveCreate = resolve;
+    });
+
+    mockDriveFiles.list.mockReturnValueOnce(listPromise);
+    mockDriveFiles.create.mockReturnValueOnce(createPromise);
+
+    const firstEnsure = driveService.ensureFolder('2026-03-16', 'parent123');
+    const secondEnsure = driveService.ensureFolder('2026-03-16', 'parent123');
+
+    expect(mockDriveFiles.list).toHaveBeenCalledTimes(1);
+    expect(mockDriveFiles.create).toHaveBeenCalledTimes(0);
+
+    resolveList({
+      data: {
+        files: []
+      }
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockDriveFiles.create).toHaveBeenCalledTimes(1);
+
+    resolveCreate({
+      data: { id: 'folder999', name: '2026-03-16' }
+    });
+
+    await expect(firstEnsure).resolves.toEqual({ id: 'folder999', name: '2026-03-16' });
+    await expect(secondEnsure).resolves.toEqual({ id: 'folder999', name: '2026-03-16' });
+  });
 });

--- a/tests/utils/file-namer.test.js
+++ b/tests/utils/file-namer.test.js
@@ -1,4 +1,6 @@
 import {
+  formatUploadDate,
+  formatUploadTime,
   generateFileName,
   sanitizeForFilename,
   handleDuplicateFilename,
@@ -46,14 +48,22 @@ describe('File Namer Utilities', () => {
   describe('generateFileName', () => {
     const fixedDate = new Date('2025-05-23T14:30:45.000Z');
 
+    test('formats the upload date for Drive folders', () => {
+      expect(formatUploadDate(fixedDate)).toBe('2025-05-23');
+    });
+
+    test('formats the upload time for file names', () => {
+      expect(formatUploadTime(fixedDate)).toBe('14-30-45');
+    });
+
     test('generates filename with author and message content', () => {
       const result = generateFileName('photo.jpg', 'Check this out!', fixedDate, 'Alice Example');
-      expect(result).toBe('2025-05-23-14-30 - Alice Example - Check this out!.jpg');
+      expect(result).toBe('Alice Example - 14-30-45 - Check this out!.jpg');
     });
 
     test('generates filename without message content', () => {
       const result = generateFileName('photo.jpg', '', fixedDate, 'Alice Example');
-      expect(result).toBe('2025-05-23-14-30 - Alice Example.jpg');
+      expect(result).toBe('Alice Example - 14-30-45.jpg');
     });
 
     test('handles different file extensions', () => {
@@ -65,7 +75,7 @@ describe('File Namer Utilities', () => {
     test('truncates comment text to first 100 characters', () => {
       const longMessage = 'a'.repeat(150);
       const result = generateFileName('photo.jpg', longMessage, fixedDate, 'Alice');
-      expect(result).toBe(`2025-05-23-14-30 - Alice - ${'a'.repeat(100)}.jpg`);
+      expect(result).toBe(`Alice - 14-30-45 - ${'a'.repeat(100)}.jpg`);
     });
 
     test('handles files with multiple dots', () => {
@@ -76,7 +86,7 @@ describe('File Namer Utilities', () => {
 
     test('falls back to Unknown user when author name is missing', () => {
       const result = generateFileName('photo.jpg', 'hello', fixedDate, '');
-      expect(result).toBe('2025-05-23-14-30 - Unknown user - hello.jpg');
+      expect(result).toBe('Unknown user - 14-30-45 - hello.jpg');
     });
   });
 

--- a/tests/utils/file-namer.test.js
+++ b/tests/utils/file-namer.test.js
@@ -2,6 +2,7 @@ import {
   formatUploadDate,
   formatUploadTime,
   generateFileName,
+  getUploadTimeZone,
   sanitizeForFilename,
   handleDuplicateFilename,
   reserveDuplicateFilename
@@ -47,46 +48,57 @@ describe('File Namer Utilities', () => {
 
   describe('generateFileName', () => {
     const fixedDate = new Date('2025-05-23T14:30:45.000Z');
+    const boundaryDate = new Date('2025-05-23T23:30:45.000Z');
 
     test('formats the upload date for Drive folders', () => {
-      expect(formatUploadDate(fixedDate)).toBe('2025-05-23');
+      expect(formatUploadDate(fixedDate, 'UTC')).toBe('2025-05-23');
     });
 
     test('formats the upload time for file names', () => {
-      expect(formatUploadTime(fixedDate)).toBe('14-30-45');
+      expect(formatUploadTime(fixedDate, 'UTC')).toBe('14-30-45');
+    });
+
+    test('uses the supplied timezone for folder dates and file times', () => {
+      expect(formatUploadDate(boundaryDate, 'Asia/Singapore')).toBe('2025-05-24');
+      expect(formatUploadTime(boundaryDate, 'Asia/Singapore')).toBe('07-30-45');
     });
 
     test('generates filename with author and message content', () => {
-      const result = generateFileName('photo.jpg', 'Check this out!', fixedDate, 'Alice Example');
+      const result = generateFileName('photo.jpg', 'Check this out!', fixedDate, 'Alice Example', 'UTC');
       expect(result).toBe('Alice Example - 14-30-45 - Check this out!.jpg');
     });
 
     test('generates filename without message content', () => {
-      const result = generateFileName('photo.jpg', '', fixedDate, 'Alice Example');
+      const result = generateFileName('photo.jpg', '', fixedDate, 'Alice Example', 'UTC');
       expect(result).toBe('Alice Example - 14-30-45.jpg');
     });
 
     test('handles different file extensions', () => {
-      expect(generateFileName('video.mp4', 'test', fixedDate, 'Alice')).toContain('.mp4');
-      expect(generateFileName('image.PNG', 'test', fixedDate, 'Alice')).toContain('.png');
-      expect(generateFileName('file.webm', 'test', fixedDate, 'Alice')).toContain('.webm');
+      expect(generateFileName('video.mp4', 'test', fixedDate, 'Alice', 'UTC')).toContain('.mp4');
+      expect(generateFileName('image.PNG', 'test', fixedDate, 'Alice', 'UTC')).toContain('.png');
+      expect(generateFileName('file.webm', 'test', fixedDate, 'Alice', 'UTC')).toContain('.webm');
     });
 
     test('truncates comment text to first 100 characters', () => {
       const longMessage = 'a'.repeat(150);
-      const result = generateFileName('photo.jpg', longMessage, fixedDate, 'Alice');
+      const result = generateFileName('photo.jpg', longMessage, fixedDate, 'Alice', 'UTC');
       expect(result).toBe(`Alice - 14-30-45 - ${'a'.repeat(100)}.jpg`);
     });
 
     test('handles files with multiple dots', () => {
-      const result = generateFileName('my.photo.backup.jpg', 'test', fixedDate, 'Alice');
+      const result = generateFileName('my.photo.backup.jpg', 'test', fixedDate, 'Alice', 'UTC');
       expect(result).toContain('.jpg');
       expect(result).toContain('test');
     });
 
     test('falls back to Unknown user when author name is missing', () => {
-      const result = generateFileName('photo.jpg', 'hello', fixedDate, '');
+      const result = generateFileName('photo.jpg', 'hello', fixedDate, '', 'UTC');
       expect(result).toBe('Unknown user - 14-30-45 - hello.jpg');
+    });
+
+    test('uses the runtime timezone by default', () => {
+      expect(typeof getUploadTimeZone()).toBe('string');
+      expect(getUploadTimeZone().length).toBeGreaterThan(0);
     });
   });
 

--- a/tests/utils/upload-status.test.js
+++ b/tests/utils/upload-status.test.js
@@ -9,13 +9,13 @@ describe('Upload status utilities', () => {
     expect(formatUploadStatusMessage({
       successfulCount: 1,
       totalCount: 1,
-      folderName: '_From Discord',
+      folderName: '_From Discord/2026-03-15',
       folderId: 'folder123',
-      uploadedFilenames: ['2026-03-15-12-54 - t.png']
+      uploadedFilenames: ['Alice Example - 12-54-11.png']
     })).toBe(
-      'Uploaded to [_From Discord](https://drive.google.com/drive/folders/folder123).\n\n' +
+      'Uploaded to [_From Discord/2026-03-15](https://drive.google.com/drive/folders/folder123).\n\n' +
       'File name:\n' +
-      '- 2026-03-15-12-54 - t.png'
+      '- Alice Example - 12-54-11.png'
     );
   });
 
@@ -23,13 +23,13 @@ describe('Upload status utilities', () => {
     expect(formatUploadStatusMessage({
       successfulCount: 3,
       totalCount: 3,
-      folderName: '_From Discord',
+      folderName: '_From Discord/2026-03-15',
       folderId: 'folder123',
-      uploadedFilenames: ['2026-03-15-12-42 - jiachenyee.jpg', '2026-03-15-12-42 - jiachenyee_1.jpg']
+      uploadedFilenames: ['Alice Example - 12-42-02.jpg', 'Alice Example - 12-42-02_1.jpg']
     })).toBe(
-      'Uploaded to [_From Discord](https://drive.google.com/drive/folders/folder123).\n\n' +
+      'Uploaded to [_From Discord/2026-03-15](https://drive.google.com/drive/folders/folder123).\n\n' +
       'File names starting from:\n' +
-      '- 2026-03-15-12-42 - jiachenyee.jpg'
+      '- Alice Example - 12-42-02.jpg'
     );
   });
 
@@ -37,13 +37,13 @@ describe('Upload status utilities', () => {
     expect(formatUploadStatusMessage({
       successfulCount: 2,
       totalCount: 3,
-      folderName: '_From Discord',
+      folderName: '_From Discord/2026-03-15',
       folderId: 'folder123',
-      uploadedFilenames: ['2026-03-15-12-42 - jiachenyee.jpg']
+      uploadedFilenames: ['Alice Example - 12-42-02.jpg']
     })).toBe(
-      'Uploaded 2/3 files to [_From Discord](https://drive.google.com/drive/folders/folder123).\n\n' +
+      'Uploaded 2/3 files to [_From Discord/2026-03-15](https://drive.google.com/drive/folders/folder123).\n\n' +
       'File name:\n' +
-      '- 2026-03-15-12-42 - jiachenyee.jpg'
+      '- Alice Example - 12-42-02.jpg'
     );
   });
 
@@ -51,7 +51,7 @@ describe('Upload status utilities', () => {
     expect(formatUploadStatusMessage({
       successfulCount: 0,
       totalCount: 2,
-      folderName: '_From Discord',
+      folderName: '_From Discord/2026-03-15',
       folderId: 'folder123',
       uploadedFilenames: []
     })).toBe('❌ Upload failed');


### PR DESCRIPTION
## Summary
- create or reuse a `YYYY-mm-dd` subfolder beneath the configured Google Drive folder before uploading
- upload into the dated subfolder and report that folder link back in Discord
- rename files to `display name - hh-mm-ss - comment.ext` and update tests/docs to match

## Testing
- npm run lint
- npm test
