### PR TITLE
Reuse existing same-day Drive folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Rules:
 - The display name uses the server display name first, then falls back to Discord global name, then username
 - Message text is truncated to the first 100 characters
 - The dated folder is created automatically if it does not already exist
+- If a same-day folder already exists with extra text after the date, that folder is reused instead of creating a new plain-date folder
 - The dated folder and time stamp use the app server's local timezone
 - If the base filename already exists, a suffix is added:
   `_1`, `_2`, `_3`, and so on

--- a/src/services/google-drive.js
+++ b/src/services/google-drive.js
@@ -86,6 +86,59 @@ export class GoogleDriveService {
     }
   }
 
+  isDatePrefixedFolderName(folderName, datePrefix) {
+    if (folderName === datePrefix) {
+      return true;
+    }
+
+    if (!folderName.startsWith(datePrefix)) {
+      return false;
+    }
+
+    const nextCharacter = folderName.charAt(datePrefix.length);
+    return Boolean(nextCharacter) && !/\d/.test(nextCharacter);
+  }
+
+  async findFolderByDatePrefix(datePrefix, parentId = null) {
+    try {
+      const clauses = [
+        'mimeType=\'application/vnd.google-apps.folder\'',
+        'trashed=false',
+        `name contains '${this.escapeDriveQueryValue(datePrefix)}'`
+      ];
+
+      if (parentId) {
+        clauses.push(`'${this.escapeDriveQueryValue(parentId)}' in parents`);
+      }
+
+      let pageToken;
+
+      do {
+        const response = await this.drive.files.list({
+          q: clauses.join(' and '),
+          fields: 'nextPageToken, files(id, name, parents)',
+          pageSize: 100,
+          pageToken,
+          orderBy: 'createdTime desc',
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true
+        });
+
+        const matchingFolder = response.data.files?.find((folder) => this.isDatePrefixedFolderName(folder.name, datePrefix));
+        if (matchingFolder) {
+          return matchingFolder;
+        }
+
+        pageToken = response.data.nextPageToken;
+      } while (pageToken);
+
+      return null;
+    } catch (error) {
+      logger.error('Failed to find folder by date prefix:', error);
+      throw new Error('Failed to search Google Drive folders');
+    }
+  }
+
   async ensureFolder(name, parentId = null) {
     const folderKey = `${parentId || 'root'}:${name}`;
     const pendingEnsure = this.pendingFolderEnsures.get(folderKey);
@@ -97,6 +150,11 @@ export class GoogleDriveService {
       const existingFolder = await this.findFolderByName(name, parentId);
       if (existingFolder) {
         return existingFolder;
+      }
+
+      const existingDatePrefixedFolder = await this.findFolderByDatePrefix(name, parentId);
+      if (existingDatePrefixedFolder) {
+        return existingDatePrefixedFolder;
       }
 
       return this.createFolder(name, parentId);

--- a/tests/services/google-drive.test.js
+++ b/tests/services/google-drive.test.js
@@ -87,6 +87,11 @@ describe('GoogleDriveService', () => {
         files: []
       }
     });
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: []
+      }
+    });
     mockDriveFiles.create.mockResolvedValueOnce({
       data: { id: 'folder789', name: '2026-03-16' }
     });
@@ -105,17 +110,105 @@ describe('GoogleDriveService', () => {
     expect(folder).toEqual({ id: 'folder789', name: '2026-03-16' });
   });
 
+  test('reuses an existing same-day child folder with a description suffix', async () => {
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: []
+      }
+    });
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: 'folder654', name: '2026-03-16 holiday album', parents: ['parent123'] }
+        ]
+      }
+    });
+
+    const folder = await driveService.ensureFolder('2026-03-16', 'parent123');
+
+    expect(mockDriveFiles.create).not.toHaveBeenCalled();
+    expect(folder).toEqual({
+      id: 'folder654',
+      name: '2026-03-16 holiday album',
+      parents: ['parent123']
+    });
+  });
+
+  test('ignores partial date matches that continue with more digits', async () => {
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: []
+      }
+    });
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: 'folder321', name: '2026-03-1601 archive', parents: ['parent123'] }
+        ]
+      }
+    });
+    mockDriveFiles.create.mockResolvedValueOnce({
+      data: { id: 'folder789', name: '2026-03-16' }
+    });
+
+    const folder = await driveService.ensureFolder('2026-03-16', 'parent123');
+
+    expect(mockDriveFiles.create).toHaveBeenCalledTimes(1);
+    expect(folder).toEqual({ id: 'folder789', name: '2026-03-16' });
+  });
+
+  test('keeps searching later pages for a same-day folder with a suffix', async () => {
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: []
+      }
+    });
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: 'folder001', name: 'misc 2026-03-16', parents: ['parent123'] }
+        ],
+        nextPageToken: 'page-2'
+      }
+    });
+    mockDriveFiles.list.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: 'folder654', name: '2026-03-16 holiday album', parents: ['parent123'] }
+        ]
+      }
+    });
+
+    const folder = await driveService.ensureFolder('2026-03-16', 'parent123');
+
+    expect(mockDriveFiles.create).not.toHaveBeenCalled();
+    expect(mockDriveFiles.list).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      pageToken: 'page-2',
+      fields: 'nextPageToken, files(id, name, parents)'
+    }));
+    expect(folder).toEqual({
+      id: 'folder654',
+      name: '2026-03-16 holiday album',
+      parents: ['parent123']
+    });
+  });
+
   test('serialises concurrent ensureFolder calls for the same child folder', async () => {
     let resolveList;
+    let resolvePrefixList;
     let resolveCreate;
     const listPromise = new Promise((resolve) => {
       resolveList = resolve;
+    });
+    const prefixListPromise = new Promise((resolve) => {
+      resolvePrefixList = resolve;
     });
     const createPromise = new Promise((resolve) => {
       resolveCreate = resolve;
     });
 
     mockDriveFiles.list.mockReturnValueOnce(listPromise);
+    mockDriveFiles.list.mockReturnValueOnce(prefixListPromise);
     mockDriveFiles.create.mockReturnValueOnce(createPromise);
 
     const firstEnsure = driveService.ensureFolder('2026-03-16', 'parent123');
@@ -125,6 +218,13 @@ describe('GoogleDriveService', () => {
     expect(mockDriveFiles.create).toHaveBeenCalledTimes(0);
 
     resolveList({
+      data: {
+        files: []
+      }
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    resolvePrefixList({
       data: {
         files: []
       }


### PR DESCRIPTION
## Summary
- reuse an existing same-day Drive subfolder when its name starts with `YYYY-mm-dd` and includes a descriptive suffix
- keep the exact-date folder as the first preference, then fall back to paginated prefix lookup before creating a new folder
- add test coverage for suffix reuse, digit-suffix rejection, and later-page matches

## Testing
- npm run lint
- npm test
