### PR TITLE
Allow changing the default folder from linked folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Self-hosted Discord bot and setup UI for uploading photos and videos from Discor
 - Google Picker-based Drive folder selection
 - Per-server and per-channel folder mapping
 - Optional default `default-for-discord` folder creation during setup
+- In-place default folder changes from the linked folders page
 - Markdown upload confirmations with folder links
 - File-backed configuration storage
 - Docker-first local and self-hosted setup
@@ -154,11 +155,12 @@ Then open the app in your browser, usually at:
 Complete the browser setup in this order:
 
 1. Connect Google Drive
-2. Enter the Discord bot token
-3. Pick a default Google Drive folder
+2. Pick a default Google Drive folder
    - You can either choose a folder directly
    - Or choose a parent folder and create a `default-for-discord` folder inside it
+3. Enter the Discord bot token
 4. Link Discord servers and channels to Drive folders
+   - You can also review and change the default fallback folder again from this page later
 
 If `SETUP_API_TOKEN` is configured, enter it when prompted before saving configuration.
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -230,6 +230,22 @@ main {
     gap: 1rem;
 }
 
+.default-folder-panel {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.default-folder-panel-header h3 {
+    margin-bottom: 0.25rem;
+}
+
+.default-folder-actions {
+    margin-top: 1rem;
+}
+
 .picker-field {
     display: flex;
     flex-direction: column;

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,30 @@
         <div class="step" data-step="5">
           <h2>⚙️ Link Servers and Channels</h2>
           <p>Choose which server and channel you want this bot to monitor, then map each channel to a Google Drive folder.</p>
+          <section class="default-folder-panel" aria-labelledby="default-folder-panel-title">
+            <div class="default-folder-panel-header">
+              <div>
+                <h3 id="default-folder-panel-title">Default fallback folder</h3>
+                <p class="info compact-info">Uploads from unmapped channels will continue to use this folder.</p>
+              </div>
+            </div>
+            <div id="current-default-folder" class="picker-inline-summary"></div>
+            <div class="picker-launcher default-folder-actions">
+              <label class="checkbox-option" for="change-default-folder-checkbox">
+                <input type="checkbox" id="change-default-folder-checkbox">
+                <span>Create a <code>default-for-discord</code> folder here for me</span>
+              </label>
+              <p class="info compact-info">If ticked, the folder you choose becomes the parent folder and we will create a new upload folder inside it.</p>
+              <button class="btn btn-secondary picker-button" id="open-change-default-folder-picker" data-default-text="Choose new default folder in Google Drive">
+                Choose new default folder in Google Drive
+              </button>
+              <div id="selected-change-default-folder" class="picker-inline-summary"></div>
+              <button class="btn btn-primary" id="save-default-folder-btn" data-default-text="Save default folder" disabled>
+                Save default folder
+              </button>
+            </div>
+            <p id="default-folder-feedback" class="info"></p>
+          </section>
           <div class="mapping-form">
             <div class="form-grid">
               <div>

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -7,6 +7,7 @@ let selectedFolderName = null;
 let createDefaultFolder = false;
 let selectedChannelFolderId = null;
 let selectedChannelFolderName = null;
+let currentDefaultFolder = null;
 let folders = [];
 let googlePickerConfig = null;
 let pickerApiReadyPromise = null;
@@ -125,6 +126,15 @@ function escapeHtml(value) {
 
 function setLinkFeedback(message, isError = false) {
   const feedback = document.getElementById('link-feedback');
+  feedback.textContent = message;
+  feedback.style.color = isError ? 'var(--error)' : 'var(--secondary-color)';
+  feedback.classList.toggle('show', Boolean(message));
+}
+
+function setDefaultFolderFeedback(message, isError = false) {
+  const feedback = document.getElementById('default-folder-feedback');
+  if (!feedback) return;
+
   feedback.textContent = message;
   feedback.style.color = isError ? 'var(--error)' : 'var(--secondary-color)';
   feedback.classList.toggle('show', Boolean(message));
@@ -413,6 +423,18 @@ async function openDefaultFolderPicker(event) {
   }
 }
 
+async function loadCurrentDefaultFolder() {
+  const response = await apiGet('/api/config-folder');
+  throwIfUnauthorized(response);
+  if (!response.ok) {
+    const message = await parseResponseError(response, 'Failed to load the default folder');
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  return data.folder || null;
+}
+
 async function loadFolders() {
   const folderList = document.getElementById('folder-list');
   folderList.innerHTML = '<div class="loading">Loading folders...</div>';
@@ -466,32 +488,37 @@ function selectFolder(folderId, folderName, element) {
   }
 }
 
-async function saveFolderAndContinue() {
+async function persistDefaultFolderSelection() {
   if (!selectedFolderId) {
-    showError('Please select a folder');
-    return;
+    throw new Error('Please select a folder');
   }
 
+  const response = await apiPost('/api/config-folder', {
+    folderId: selectedFolderId,
+    folderName: selectedFolderName,
+    createDefaultFolder
+  });
+  throwIfUnauthorized(response);
+  if (!response.ok) {
+    const message = await parseResponseError(response, 'Failed to save folder configuration');
+    throw new Error(message);
+  }
+
+  const result = await response.json();
+  if (result.folder?.id && result.folder?.name) {
+    selectedFolderId = result.folder.id;
+    selectedFolderName = result.folder.name;
+    currentDefaultFolder = result.folder;
+  }
+
+  return result;
+}
+
+async function saveFolderAndContinue() {
   const button = document.getElementById('continue-folder');
   setButtonLoading(button, true);
   try {
-    const response = await apiPost('/api/config-folder', {
-      folderId: selectedFolderId,
-      folderName: selectedFolderName,
-      createDefaultFolder
-    });
-    throwIfUnauthorized(response);
-    if (!response.ok) {
-      const message = await parseResponseError(response, 'Failed to save folder configuration');
-      throw new Error(message);
-    }
-
-    const result = await response.json();
-    if (result.folder?.id && result.folder?.name) {
-      selectedFolderId = result.folder.id;
-      selectedFolderName = result.folder.name;
-    }
-
+    await persistDefaultFolderSelection();
     nextStep();
   } catch (error) {
     showError(`Failed to save folder: ${error.message}`);
@@ -582,6 +609,113 @@ async function loadChannelConfigs() {
   return data.configs || [];
 }
 
+function updateCurrentDefaultFolderSummary() {
+  const selectedFolder = document.getElementById('current-default-folder');
+  if (!selectedFolder) return;
+
+  if (!currentDefaultFolder?.id || !currentDefaultFolder?.name) {
+    selectedFolder.innerHTML = '<p class="info">No default folder is configured yet.</p>';
+    return;
+  }
+
+  selectedFolder.innerHTML = `
+    <div class="picker-selection">
+      <strong>Current default folder</strong>
+      <span>${escapeHtml(currentDefaultFolder.name)}</span>
+    </div>
+  `;
+}
+
+function updateChangeDefaultFolderSummary() {
+  const selectedFolder = document.getElementById('selected-change-default-folder');
+  const saveButton = document.getElementById('save-default-folder-btn');
+  if (!selectedFolder) return;
+
+  if (!selectedFolderId || !selectedFolderName) {
+    selectedFolder.innerHTML = createDefaultFolder
+      ? `<p class="info">No parent folder selected yet. We will create <code>${escapeHtml(DEFAULT_DISCORD_FOLDER_NAME)}</code> inside the folder you pick.</p>`
+      : '<p class="info">No replacement folder selected yet.</p>';
+    if (saveButton) {
+      saveButton.disabled = true;
+    }
+    return;
+  }
+
+  if (createDefaultFolder) {
+    selectedFolder.innerHTML = `
+      <div class="picker-selection">
+        <strong>Selected parent folder</strong>
+        <span>${escapeHtml(selectedFolderName)}</span>
+        <small>A new <code>${escapeHtml(DEFAULT_DISCORD_FOLDER_NAME)}</code> folder will be created inside this location and used for uploads.</small>
+      </div>
+    `;
+  } else {
+    selectedFolder.innerHTML = `
+      <div class="picker-selection">
+        <strong>Selected folder</strong>
+        <span>${escapeHtml(selectedFolderName)}</span>
+      </div>
+    `;
+  }
+
+  if (saveButton) {
+    saveButton.disabled = false;
+  }
+}
+
+function resetDefaultFolderDraftSelection() {
+  selectedFolderId = null;
+  selectedFolderName = null;
+  createDefaultFolder = false;
+
+  const checkbox = document.getElementById('change-default-folder-checkbox');
+  if (checkbox) {
+    checkbox.checked = false;
+  }
+
+  updateChangeDefaultFolderSummary();
+}
+
+async function openChangeDefaultFolderPicker(event) {
+  const button = event.currentTarget;
+  setButtonLoading(button, true);
+
+  try {
+    const pickerTitle = createDefaultFolder
+      ? 'Select where to create your new default-for-discord folder'
+      : 'Select a new default Google Drive folder';
+
+    await openDriveFolderPicker(pickerTitle, (folder) => {
+      selectedFolderId = folder.id;
+      selectedFolderName = folder.name;
+      updateChangeDefaultFolderSummary();
+    });
+  } catch (error) {
+    setDefaultFolderFeedback(error.message, true);
+  } finally {
+    setButtonLoading(button, false);
+  }
+}
+
+async function saveChangedDefaultFolder() {
+  const button = document.getElementById('save-default-folder-btn');
+  setButtonLoading(button, true);
+  setDefaultFolderFeedback('');
+
+  try {
+    const result = await persistDefaultFolderSelection();
+    currentDefaultFolder = result.folder || null;
+    updateCurrentDefaultFolderSummary();
+    resetDefaultFolderDraftSelection();
+    setDefaultFolderFeedback(result.message || 'Default folder updated.');
+  } catch (error) {
+    setDefaultFolderFeedback(error.message, true);
+  } finally {
+    setButtonLoading(button, false);
+    updateChangeDefaultFolderSummary();
+  }
+}
+
 async function loadMappingStep() {
   const guildSelector = document.getElementById('guild-selector');
   const channelSelector = document.getElementById('channel-selector');
@@ -589,39 +723,52 @@ async function loadMappingStep() {
   if (!guildSelector || !channelSelector || !folderPickerButton) return;
 
   setLinkFeedback('');
+  setDefaultFolderFeedback('');
+  resetDefaultFolderDraftSelection();
 
   guildSelector.innerHTML = '<option value="">Loading servers...</option>';
   channelSelector.innerHTML = '<option value="">Select a server first</option>';
   updateChannelFolderSummary();
+  try {
+    currentDefaultFolder = await loadCurrentDefaultFolder();
+    updateCurrentDefaultFolderSummary();
 
-  guilds = await loadGuilds();
-  guildSelector.innerHTML = guilds.length
-    ? '<option value="">Select a server</option>'
-    : '<option value="">Invite the bot to a server first</option>';
-  if (!guilds.length) {
+    guilds = await loadGuilds();
+    guildSelector.innerHTML = guilds.length
+      ? '<option value="">Select a server</option>'
+      : '<option value="">Invite the bot to a server first</option>';
+    if (!guilds.length) {
+      channelSelector.disabled = true;
+      document.getElementById('link-channel-btn').disabled = true;
+    } else {
+      document.getElementById('link-channel-btn').disabled = false;
+    }
+
+    guilds.forEach((guild) => {
+      const option = document.createElement('option');
+      option.value = guild.id;
+      option.textContent = guild.name;
+      guildSelector.appendChild(option);
+    });
+
+    const links = await loadChannelConfigs();
+    channelConfigs.clear();
+    links.forEach((config) => {
+      channelConfigs.set(`${config.guildId}:${config.channelId}`, config);
+    });
+    renderChannelLinks();
+
+    guildSelector.onchange = onGuildSelectionChange;
+    if (guilds.length > 0) {
+      channelSelector.disabled = true;
+    }
+  } catch (error) {
+    console.error('Failed to load linked folders step:', error);
+    setLinkFeedback(error.message || 'Failed to load linked folders.', true);
+    guildSelector.innerHTML = '<option value="">Unable to load servers</option>';
+    channelSelector.innerHTML = '<option value="">Unable to load channels</option>';
     channelSelector.disabled = true;
     document.getElementById('link-channel-btn').disabled = true;
-  } else {
-    document.getElementById('link-channel-btn').disabled = false;
-  }
-
-  guilds.forEach((guild) => {
-    const option = document.createElement('option');
-    option.value = guild.id;
-    option.textContent = guild.name;
-    guildSelector.appendChild(option);
-  });
-
-  const links = await loadChannelConfigs();
-  channelConfigs.clear();
-  links.forEach((config) => {
-    channelConfigs.set(`${config.guildId}:${config.channelId}`, config);
-  });
-  renderChannelLinks();
-
-  guildSelector.onchange = onGuildSelectionChange;
-  if (guilds.length > 0) {
-    channelSelector.disabled = true;
   }
 }
 
@@ -793,6 +940,12 @@ function setupMappingActions() {
   const button = document.getElementById('link-channel-btn');
   button?.addEventListener('click', linkChannelToFolder);
   document.getElementById('open-channel-folder-picker')?.addEventListener('click', openChannelFolderPicker);
+  document.getElementById('open-change-default-folder-picker')?.addEventListener('click', openChangeDefaultFolderPicker);
+  document.getElementById('save-default-folder-btn')?.addEventListener('click', saveChangedDefaultFolder);
+  document.getElementById('change-default-folder-checkbox')?.addEventListener('change', (event) => {
+    createDefaultFolder = event.currentTarget.checked;
+    updateChangeDefaultFolderSummary();
+  });
 }
 
 async function openChannelFolderPicker(event) {

--- a/src/handlers/message-handler.js
+++ b/src/handlers/message-handler.js
@@ -81,8 +81,7 @@ export class DiscordBot {
     const { guild, channel } = message;
     if (!guild) return;
     
-    // Get channel configuration
-    const channelConfig = await this.configStore.getChannelFolder(guild.id, channel.id);
+    const channelConfig = await this.configStore.getUploadFolder(guild.id, channel.id);
     if (!channelConfig) {
       logger.debug(`No upload configuration for channel ${channel.id}`);
       return;

--- a/src/handlers/slash-commands.js
+++ b/src/handlers/slash-commands.js
@@ -106,7 +106,7 @@ async function handleUploadInfo(interaction) {
   const configStore = new ConfigStore();
   await configStore.initialize();
 
-  const channelConfig = await configStore.getChannelFolder(guild_id, channel_id);
+  const channelConfig = await configStore.getUploadFolder(guild_id, channel_id);
   
   if (!channelConfig) {
     return createResponse(
@@ -114,10 +114,16 @@ async function handleUploadInfo(interaction) {
     );
   }
 
-  const configuredDate = new Date(channelConfig.configuredAt).toLocaleDateString();
+  const configuredDate = channelConfig.configuredAt
+    ? new Date(channelConfig.configuredAt).toLocaleDateString()
+    : 'Unknown';
+  const sourceLabel = channelConfig.source === 'default'
+    ? 'Default fallback folder'
+    : 'Channel-specific folder';
   
   return createResponse(
     '📁 **Upload Configuration**\n' +
+    `Source: **${sourceLabel}**\n` +
     `Folder: **${channelConfig.folderName}**\n` +
     `Configured on: ${configuredDate}`
   );

--- a/src/index.js
+++ b/src/index.js
@@ -412,6 +412,15 @@ const server = createServer(async (req, res) => {
       }));
     }
 
+    if (method === 'GET' && pathname === '/api/config-folder') {
+      if (!isAuthorizedSetupRequest(req, res)) return;
+
+      const folder = await configStore.getDefaultFolder();
+      return sendResponse(res, json({
+        folder: folder || null
+      }));
+    }
+
     if (method === 'POST' && pathname === '/api/config-folder') {
       if (!isAuthorizedSetupRequest(req, res)) return;
 

--- a/src/services/config-store.js
+++ b/src/services/config-store.js
@@ -116,6 +116,39 @@ export class ConfigStore {
     }
   }
 
+  async getUploadFolder(guildId, channelId) {
+    try {
+      const channelConfig = await this.getChannelFolder(guildId, channelId);
+      if (channelConfig) {
+        return {
+          ...channelConfig,
+          source: 'channel'
+        };
+      }
+
+      const guildConfig = await this.getGuildConfig(guildId);
+      if (guildConfig.channels?.[channelId]?.enabled === false) {
+        return null;
+      }
+
+      const defaultFolder = await this.getDefaultFolder();
+      if (!defaultFolder?.id || !defaultFolder?.name) {
+        return null;
+      }
+
+      return {
+        driveFolderId: defaultFolder.id,
+        folderName: defaultFolder.name,
+        configuredAt: defaultFolder.configuredAt || null,
+        enabled: true,
+        source: 'default'
+      };
+    } catch (error) {
+      logger.error('Failed to resolve upload folder:', error);
+      return null;
+    }
+  }
+
   async setChannelSyncEnabled(guildId, channelId, enabled) {
     try {
       const guildConfig = await this.getGuildConfig(guildId);

--- a/tests/services/config-store.test.js
+++ b/tests/services/config-store.test.js
@@ -122,6 +122,67 @@ describe('ConfigStore', () => {
       expect(result).toBeNull();
     });
 
+    test('falls back to the default folder for uploads when a channel is unmapped', async () => {
+      mockStore.get
+        .mockResolvedValueOnce({ channels: {} })
+        .mockResolvedValueOnce({ channels: {} })
+        .mockResolvedValueOnce({
+          id: 'default123',
+          name: 'Fallback Uploads',
+          configuredAt: 1710000000000
+        });
+
+      const result = await configStore.getUploadFolder('guild123', 'unmapped-channel');
+      expect(result).toEqual({
+        driveFolderId: 'default123',
+        folderName: 'Fallback Uploads',
+        configuredAt: 1710000000000,
+        enabled: true,
+        source: 'default'
+      });
+    });
+
+    test('prefers the channel folder over the default folder for uploads', async () => {
+      mockStore.get.mockResolvedValueOnce({
+        channels: {
+          channel456: {
+            driveFolderId: 'folder789',
+            folderName: 'Channel Folder',
+            configuredAt: 1710000000001,
+            enabled: true
+          }
+        }
+      });
+
+      const result = await configStore.getUploadFolder('guild123', 'channel456');
+      expect(result).toEqual({
+        driveFolderId: 'folder789',
+        folderName: 'Channel Folder',
+        configuredAt: 1710000000001,
+        enabled: true,
+        source: 'channel'
+      });
+    });
+
+    test('does not fall back when a channel mapping is explicitly disabled', async () => {
+      const disabledChannelConfig = {
+        channels: {
+          channel456: {
+            driveFolderId: 'folder789',
+            folderName: 'Channel Folder',
+            configuredAt: 1710000000001,
+            enabled: false
+          }
+        }
+      };
+      mockStore.get
+        .mockResolvedValueOnce(disabledChannelConfig)
+        .mockResolvedValueOnce(disabledChannelConfig);
+
+      const result = await configStore.getUploadFolder('guild123', 'channel456');
+      expect(result).toBeNull();
+    });
+
     test('stores the default folder in the backing store', async () => {
       await configStore.setDefaultFolder('folder123', 'Uploads');
 
@@ -129,6 +190,32 @@ describe('ConfigStore', () => {
         id: 'folder123',
         name: 'Uploads',
         configuredAt: expect.any(Number)
+      });
+    });
+
+    test('gets the stored default folder metadata', async () => {
+      const defaultFolder = {
+        id: 'folder123',
+        name: 'Uploads',
+        configuredAt: 1710000000000
+      };
+      mockStore.get.mockResolvedValueOnce(defaultFolder);
+
+      const result = await configStore.getDefaultFolder();
+      expect(mockStore.get).toHaveBeenCalledWith('default_folder');
+      expect(result).toEqual(defaultFolder);
+    });
+
+    test('parses legacy stringified default folder metadata', async () => {
+      mockStore.get.mockResolvedValueOnce(JSON.stringify({
+        id: 'folder123',
+        name: 'Uploads'
+      }));
+
+      const result = await configStore.getDefaultFolder();
+      expect(result).toEqual({
+        id: 'folder123',
+        name: 'Uploads'
       });
     });
   });


### PR DESCRIPTION
## Summary
- show the current default fallback Google Drive folder on the linked folders step
- let the user change that default folder in place using the existing Google Picker flow
- make unmapped channel uploads resolve through the stored default folder immediately

## Testing
- npm run lint
- npm test
- node --check public/js/setup.js

Closes #3
