### PR TITLE
fix: require explicit opt-in for default folder uploads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,7 @@
             <div class="default-folder-panel-header">
               <div>
                 <h3 id="default-folder-panel-title">Default fallback folder</h3>
-                <p class="info compact-info">Uploads from unmapped channels will continue to use this folder.</p>
+                <p class="info compact-info">Channels explicitly linked to the default folder will upload here.</p>
               </div>
             </div>
             <div id="current-default-folder" class="picker-inline-summary"></div>
@@ -92,7 +92,10 @@
                 </div>
               </div>
             </div>
-            <button class="btn btn-primary" id="link-channel-btn">Link channel to folder</button>
+            <div class="link-channel-actions">
+              <button class="btn btn-primary" id="link-channel-btn">Link channel to folder</button>
+              <button class="btn btn-secondary" id="link-channel-default-btn">Link channel to default folder</button>
+            </div>
             <p class="info">You can add as many channel mappings as you want.</p>
             <h3 style="margin-top: 1.5rem;">Active channel links</h3>
             <div id="channel-links-list" class="mapping-list"></div>

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -740,8 +740,10 @@ async function loadMappingStep() {
     if (!guilds.length) {
       channelSelector.disabled = true;
       document.getElementById('link-channel-btn').disabled = true;
+      document.getElementById('link-channel-default-btn').disabled = true;
     } else {
       document.getElementById('link-channel-btn').disabled = false;
+      document.getElementById('link-channel-default-btn').disabled = false;
     }
 
     guilds.forEach((guild) => {
@@ -769,6 +771,7 @@ async function loadMappingStep() {
     channelSelector.innerHTML = '<option value="">Unable to load channels</option>';
     channelSelector.disabled = true;
     document.getElementById('link-channel-btn').disabled = true;
+    document.getElementById('link-channel-default-btn').disabled = true;
   }
 }
 
@@ -816,7 +819,7 @@ function renderChannelLinks() {
         <div class="mapping-item">
           <div>
             <strong>${config.guildName || config.guildId}</strong><br>
-            <small>${formatChannelLabel(config.channelId)} → ${config.folderName || 'No folder'}</small>
+            <small>${formatChannelLabel(config.channelId)} → ${config.useDefault ? '(default folder)' : config.folderName || 'No folder'}</small>
           </div>
           <div class="actions">
             <button class="btn btn-primary" data-action="toggle" data-key="${key}">
@@ -908,6 +911,44 @@ async function linkChannelToFolder() {
   }
 }
 
+async function linkChannelToDefaultFolder() {
+  const guildId = getInputValue('guild-selector');
+  const channelId = getInputValue('channel-selector');
+
+  if (!guildId || !channelId) {
+    setLinkFeedback('Pick a server and channel before linking.', true);
+    return;
+  }
+
+  if (!currentDefaultFolder) {
+    setLinkFeedback('No default folder is configured. Set a default folder first.', true);
+    return;
+  }
+
+  setLinkFeedback('');
+  const button = document.getElementById('link-channel-default-btn');
+  addLoadingText(button, 'Linking...');
+
+  try {
+    const response = await apiPost('/api/config-channel', {
+      guildId,
+      channelId
+    });
+    throwIfUnauthorized(response);
+    if (!response.ok) {
+      const message = await parseResponseError(response, 'Failed to link channel');
+      throw new Error(message);
+    }
+
+    await loadMappingStep();
+    setLinkFeedback('Channel linked to default folder.');
+  } catch (error) {
+    setLinkFeedback(error.message, true);
+  } finally {
+    clearLoadingText(button, 'Link channel to default folder');
+  }
+}
+
 async function updateChannelMapping(guildId, channelId, updates) {
   const response = await apiPost('/api/config-channel', {
     guildId,
@@ -939,6 +980,7 @@ async function removeChannelMapping(guildId, channelId) {
 function setupMappingActions() {
   const button = document.getElementById('link-channel-btn');
   button?.addEventListener('click', linkChannelToFolder);
+  document.getElementById('link-channel-default-btn')?.addEventListener('click', linkChannelToDefaultFolder);
   document.getElementById('open-channel-folder-picker')?.addEventListener('click', openChannelFolderPicker);
   document.getElementById('open-change-default-folder-picker')?.addEventListener('click', openChangeDefaultFolderPicker);
   document.getElementById('save-default-folder-btn')?.addEventListener('click', saveChangedDefaultFolder);

--- a/src/index.js
+++ b/src/index.js
@@ -569,15 +569,22 @@ const server = createServer(async (req, res) => {
         }));
       }
 
-      const { folderId, folderName } = body;
-      const useDefault = !folderId;
+      const rawFolderId = body.folderId;
+      const rawFolderName = body.folderName;
+      const useDefault = rawFolderId == null;
+      const folderId = typeof rawFolderId === 'string' ? rawFolderId.trim() : rawFolderId;
+      const folderName = typeof rawFolderName === 'string' ? rawFolderName.trim() : rawFolderName;
 
       // Allow folderId to be null/omitted to link the channel to the default folder
-      if (!useDefault && !folderName) {
+      if (!useDefault && (typeof folderId !== 'string' || !folderId)) {
+        return sendResponse(res, json({ error: 'folderId must be a non-empty string when specifying a folder' }, 400));
+      }
+
+      if (!useDefault && (typeof folderName !== 'string' || !folderName)) {
         return sendResponse(res, json({ error: 'folderName is required when specifying a folderId' }, 400));
       }
 
-      await configStore.setChannelFolder(guildId, channelId, folderId || null, folderName || null, true);
+      await configStore.setChannelFolder(guildId, channelId, useDefault ? null : folderId, useDefault ? null : folderName, true);
       return sendResponse(res, json({
         success: true,
         action: 'enabled',

--- a/src/index.js
+++ b/src/index.js
@@ -570,19 +570,21 @@ const server = createServer(async (req, res) => {
       }
 
       const { folderId, folderName } = body;
-      if (!folderId || !folderName) {
-        return sendResponse(res, json({ error: 'folderId and folderName are required when enabling a mapping' }, 400));
+      const useDefault = !folderId;
+
+      // Allow folderId to be null/omitted to link the channel to the default folder
+      if (!useDefault && !folderName) {
+        return sendResponse(res, json({ error: 'folderName is required when specifying a folderId' }, 400));
       }
 
-      await configStore.setChannelFolder(guildId, channelId, folderId, folderName, true);
+      await configStore.setChannelFolder(guildId, channelId, folderId || null, folderName || null, true);
       return sendResponse(res, json({
         success: true,
         action: 'enabled',
         mapping: {
           guildId,
           channelId,
-          folderId,
-          folderName
+          ...(useDefault ? { useDefault: true } : { folderId, folderName })
         }
       }));
     }

--- a/src/services/config-store.js
+++ b/src/services/config-store.js
@@ -77,6 +77,20 @@ export class ConfigStore {
   }
 
   async setChannelFolder(guildId, channelId, folderId, folderName, enabled = true) {
+    const useDefault = folderId == null;
+    const normalizedFolderId = typeof folderId === 'string' ? folderId.trim() : folderId;
+    const normalizedFolderName = typeof folderName === 'string' ? folderName.trim() : folderName;
+
+    if (!useDefault) {
+      if (typeof normalizedFolderId !== 'string' || !normalizedFolderId) {
+        throw new Error('Channel folder ID must be a non-empty string');
+      }
+
+      if (typeof normalizedFolderName !== 'string' || !normalizedFolderName) {
+        throw new Error('Channel folder name is required when specifying a folder');
+      }
+    }
+
     try {
       const guildConfig = await this.getGuildConfig(guildId);
 
@@ -84,15 +98,14 @@ export class ConfigStore {
         guildConfig.channels = {};
       }
 
-      const useDefault = !folderId;
       guildConfig.channels[channelId] = {
-        ...(useDefault ? { useDefault: true } : { driveFolderId: folderId, folderName: folderName }),
+        ...(useDefault ? { useDefault: true } : { driveFolderId: normalizedFolderId, folderName: normalizedFolderName }),
         configuredAt: Date.now(),
         enabled
       };
 
       await this.setGuildConfig(guildId, guildConfig);
-      logger.info(`Set folder ${useDefault ? '(default)' : folderName} for channel ${channelId} in guild ${guildId}`);
+      logger.info(`Set folder ${useDefault ? '(default)' : normalizedFolderName} for channel ${channelId} in guild ${guildId}`);
     } catch (error) {
       logger.error('Failed to set channel folder:', error);
       throw new Error('Failed to configure channel folder');

--- a/src/services/config-store.js
+++ b/src/services/config-store.js
@@ -79,20 +79,20 @@ export class ConfigStore {
   async setChannelFolder(guildId, channelId, folderId, folderName, enabled = true) {
     try {
       const guildConfig = await this.getGuildConfig(guildId);
-      
+
       if (!guildConfig.channels) {
         guildConfig.channels = {};
       }
-      
+
+      const useDefault = !folderId;
       guildConfig.channels[channelId] = {
-        driveFolderId: folderId,
-        folderName: folderName,
+        ...(useDefault ? { useDefault: true } : { driveFolderId: folderId, folderName: folderName }),
         configuredAt: Date.now(),
         enabled
       };
-      
+
       await this.setGuildConfig(guildId, guildConfig);
-      logger.info(`Set folder ${folderName} for channel ${channelId} in guild ${guildId}`);
+      logger.info(`Set folder ${useDefault ? '(default)' : folderName} for channel ${channelId} in guild ${guildId}`);
     } catch (error) {
       logger.error('Failed to set channel folder:', error);
       throw new Error('Failed to configure channel folder');
@@ -105,6 +105,10 @@ export class ConfigStore {
       if (guildConfig.channels?.[channelId]) {
         const channelConfig = guildConfig.channels[channelId];
         if (channelConfig?.enabled === false) {
+          return null;
+        }
+        // useDefault channels are resolved by getUploadFolder, not here
+        if (channelConfig?.useDefault) {
           return null;
         }
         return channelConfig;
@@ -127,7 +131,15 @@ export class ConfigStore {
       }
 
       const guildConfig = await this.getGuildConfig(guildId);
-      if (guildConfig.channels?.[channelId]?.enabled === false) {
+      const entry = guildConfig.channels?.[channelId];
+
+      // No config at all, or explicitly disabled — don't upload
+      if (!entry || entry.enabled === false) {
+        return null;
+      }
+
+      // Only fall back to the default folder for channels explicitly linked to it
+      if (!entry.useDefault) {
         return null;
       }
 
@@ -203,8 +215,9 @@ export class ConfigStore {
           mappings.push({
             guildId,
             channelId,
-            folderId: config.driveFolderId,
-            folderName: config.folderName,
+            folderId: config.driveFolderId || null,
+            folderName: config.folderName || null,
+            useDefault: config.useDefault === true,
             enabled: config.enabled !== false,
             configuredAt: config.configuredAt || null
           });

--- a/tests/services/config-store.test.js
+++ b/tests/services/config-store.test.js
@@ -99,6 +99,22 @@ describe('ConfigStore', () => {
       });
     });
 
+    test('sets channel folder to use default when folderId is null', async () => {
+      mockStore.get.mockResolvedValueOnce({ channels: {} });
+
+      await configStore.setChannelFolder('guild123', 'channel456', null, null);
+
+      expect(mockStore.setJSON).toHaveBeenCalledWith('guild_guild123', {
+        channels: {
+          channel456: {
+            useDefault: true,
+            configuredAt: expect.any(Number),
+            enabled: true
+          }
+        }
+      });
+    });
+
     test('gets channel folder configuration', async () => {
       const guildConfig = {
         channels: {
@@ -122,17 +138,35 @@ describe('ConfigStore', () => {
       expect(result).toBeNull();
     });
 
-    test('falls back to the default folder for uploads when a channel is unmapped', async () => {
+    test('does not fall back to the default folder for uploads when a channel is unmapped', async () => {
       mockStore.get
         .mockResolvedValueOnce({ channels: {} })
-        .mockResolvedValueOnce({ channels: {} })
+        .mockResolvedValueOnce({ channels: {} });
+
+      const result = await configStore.getUploadFolder('guild123', 'unmapped-channel');
+      expect(result).toBeNull();
+    });
+
+    test('falls back to the default folder for uploads when a channel is explicitly linked to the default', async () => {
+      const guildConfig = {
+        channels: {
+          'default-channel': {
+            useDefault: true,
+            configuredAt: 1710000000000,
+            enabled: true
+          }
+        }
+      };
+      mockStore.get
+        .mockResolvedValueOnce(guildConfig)
+        .mockResolvedValueOnce(guildConfig)
         .mockResolvedValueOnce({
           id: 'default123',
           name: 'Fallback Uploads',
           configuredAt: 1710000000000
         });
 
-      const result = await configStore.getUploadFolder('guild123', 'unmapped-channel');
+      const result = await configStore.getUploadFolder('guild123', 'default-channel');
       expect(result).toEqual({
         driveFolderId: 'default123',
         folderName: 'Fallback Uploads',

--- a/tests/services/config-store.test.js
+++ b/tests/services/config-store.test.js
@@ -115,6 +115,14 @@ describe('ConfigStore', () => {
       });
     });
 
+    test('rejects blank folder IDs instead of treating them as the default folder', async () => {
+      await expect(
+        configStore.setChannelFolder('guild123', 'channel456', '   ', 'My Folder')
+      ).rejects.toThrow('Channel folder ID must be a non-empty string');
+
+      expect(mockStore.setJSON).not.toHaveBeenCalled();
+    });
+
     test('gets channel folder configuration', async () => {
       const guildConfig = {
         channels: {


### PR DESCRIPTION
PR #7 re-introduced the bug fixed in 427d095 by adding getUploadFolder
which fell back to the default folder for all unmapped channels. Now the
default folder is only used when a channel is explicitly linked to it
(useDefault: true), not for every unconfigured channel in the guild.

- getUploadFolder only falls back to the default folder when the channel
  entry has useDefault: true; unmapped channels return null as before
- setChannelFolder accepts folderId=null to mark a channel as useDefault
- /api/config-channel allows omitting folderId to link to default folder
- Setup UI adds a "Link channel to default folder" button and updates the
  default folder panel description to reflect the new opt-in behaviour
- Tests updated accordingly

https://claude.ai/code/session_01GqmhX4a1vJq5Y4mS51qiJb